### PR TITLE
Enable GPUs in quinn. 

### DIFF
--- a/examples/ex_fit.py
+++ b/examples/ex_fit.py
@@ -23,6 +23,14 @@ def main():
 
     torch.set_default_dtype(torch.double)
     myrc()
+    # defaults to cuda:0
+    device_id='cuda:0'
+    # use: ./ex_ufit uq_method device_id, where uq_method: 'mcmc' 'vi' 'ens', and 
+    # device_id: cuda:0, cuda:1,... depending on number of gpus
+    if len(sys.argv) > 1:
+        device_id=sys.argv[1]
+    device = torch.device(device_id if torch.cuda.is_available() else 'cpu')
+    print("Using device",device)
 
 
     ########################################################################################
@@ -59,7 +67,8 @@ def main():
 
     # Model to fit
     nnet = MLP(ndim, nout, (11,11,11), biasorno=True,
-               activ='tanh', bnorm=False, bnlearn=True, dropout=0.0)
+               activ='tanh', bnorm=False, bnlearn=True, dropout=0.0,
+               device=device)
 
     # Data split to training and validation
     ntrn = int(trn_factor * nall)
@@ -68,10 +77,8 @@ def main():
     indval = indperm[ntrn:]
     xtrn, xval = xall[indtrn, :], xall[indval, :]
     ytrn, yval = yall[indtrn, :], yall[indval, :]
-
-
+    
     nnet.fit(xtrn, ytrn, val=[xval, yval], lrate=0.01, batch_size=None, nepochs=2000, loss=None)
-
 
     print("=======================================")
     # print("Best Parameters : ")

--- a/examples/ex_fit_2d.py
+++ b/examples/ex_fit_2d.py
@@ -22,6 +22,14 @@ def main():
     torch.set_default_dtype(torch.double)
     myrc()
 
+    # defaults to cuda:0
+    device_id='cuda:0'
+    # use: ./ex_ufit uq_method device_id, where uq_method: 'mcmc' 'vi' 'ens', and 
+    # device_id: 0, 1,... depending on number of gpus
+    if len(sys.argv) > 1:
+        device_id=sys.argv[1]
+    device = torch.device(device_id if torch.cuda.is_available() else 'cpu')
+    print("Using device",device)
 
     ###########################################################################
     ###########################################################################
@@ -52,7 +60,8 @@ def main():
 
     # Model to fit
     nnet = MLP(ndim, nout, (11,11,11), biasorno=True,
-               activ='tanh', bnorm=False, bnlearn=True, dropout=0.0)
+               activ='tanh', bnorm=False, bnlearn=True, dropout=0.0,
+               device=device)
 
     # Data split to training and validation
     ntrn = int(trn_factor * nall)
@@ -69,7 +78,8 @@ def main():
     bdry1[:,1] = np.linspace(-1.5, 1.5, ngr)
     bdry2 = 1.5*np.ones((ngr, ndim))
     bdry2[:,1] = np.linspace(-1.5, 1.5, ngr)
-    loss = PeriodicLoss([nnet.nnmodel, 10.1, tch(bdry1), tch(bdry2)]) #None #CustomLoss([nnet.nnmodel, 1.0])
+    # pass input tensors with device 
+    loss = PeriodicLoss([nnet.nnmodel, 10.1, tch(bdry1,device=device), tch(bdry2,device=device)]) #None #CustomLoss([nnet.nnmodel, 1.0])
     nnet.fit(xtrn, ytrn, val=[xval, yval], lrate=0.01, batch_size=10, nepochs=1000, loss=loss)
     print("=======================================")
 

--- a/examples/ex_ufit.py
+++ b/examples/ex_ufit.py
@@ -26,10 +26,18 @@ def main():
     torch.set_default_dtype(torch.double)
     myrc()
 
-
     #################################################################################
     #################################################################################
     meth = sys.argv[1] #'mcmc' #'vi' #'ens'
+
+    # defaults to cuda:0
+    device_id='cuda:0'
+    # use: ./ex_ufit uq_method device_id, where uq_method: 'mcmc' 'vi' 'ens', and 
+    # device_id: cuda:0, cuda:1,... depending on number of gpus
+    if len(sys.argv) > 2:
+        device_id=sys.argv[2]
+    device = torch.device(device_id if torch.cuda.is_available() else 'cpu')
+    print("Using device",device)
 
 
     nall = 12 # total number of points
@@ -68,7 +76,8 @@ def main():
                 indim=ndim, outdim=nout,
                 layer_pre=True, layer_post=True,
                 biasorno=True, nonlin=True,
-                mlp=False, final_layer=None)
+                mlp=False, final_layer=None,
+                device=device)
 
     # nnet = MLP(ndim, nout, (11,11,11), biasorno=True,
     #                  activ='relu', bnorm=False, bnlearn=True, dropout=0.0)

--- a/quinn/ens/learner.py
+++ b/quinn/ens/learner.py
@@ -78,4 +78,6 @@ class Learner():
             np.ndarray: Output array of size `(N,o)`.
         """
         assert(self.trained)
-        return npy(self.best_model(tch(x, rgrad=False)))
+        device = self.best_model.device
+        y = self.best_model(tch(x, rgrad=False, device=device))
+        return npy(y)

--- a/quinn/nns/mlp.py
+++ b/quinn/nns/mlp.py
@@ -21,7 +21,7 @@ class MLP(MLPBase):
 
     def __init__(self, indim, outdim, hls, biasorno=True,
                  activ='relu', bnorm=False, bnlearn=True, dropout=0.0,
-                 final_transform=None):
+                 final_transform=None, device='cpu'):
         """Initialization.
 
         Args:
@@ -35,7 +35,7 @@ class MLP(MLPBase):
             dropout (float, optional): Dropout fraction. Default is 0.0.
             final_transform (str, optional): Final transform, if any (onle 'exp' is implemented). Default is None.
         """
-        super(MLP, self).__init__(indim, outdim)
+        super(MLP, self).__init__(indim, outdim, device=device)
 
         self.nlayers = len(hls)
         assert(self.nlayers > 0)
@@ -83,6 +83,8 @@ class MLP(MLPBase):
 
 
         self.nnmodel = torch.nn.Sequential(*modules)
+        # sync model to device
+        self.to(device)
 
 
 

--- a/quinn/nns/mlp.py
+++ b/quinn/nns/mlp.py
@@ -27,6 +27,7 @@ class MLP(MLPBase):
         Args:
             indim (int): Input dimensionality.
             outdim (int): Output dimensionality.
+            device (str): It represents where computations are performed and tensors are allocated. Default to cpu.
             hls (tuple): Tuple of hidden layer widths.
             biasorno (bool): Whether biases are included or not.
             activ (str, optional): Activation function. Options are 'tanh', 'relu', 'sin' or else identity is used.

--- a/quinn/nns/nnbase.py
+++ b/quinn/nns/nnbase.py
@@ -29,6 +29,7 @@ class MLPBase(torch.nn.Module):
         Args:
             indim (int): Input dimensionality, `d`.
             outdim (int): Output dimensionality, `o`.
+            device (str): It represents where computations are performed and tensors are allocated. Default to cpu.
         """
         super().__init__()
         self.indim = indim

--- a/quinn/nns/nnbase.py
+++ b/quinn/nns/nnbase.py
@@ -23,7 +23,7 @@ class MLPBase(torch.nn.Module):
         history (list[np.ndarray]): List containing training history, namely, [fepoch, loss_trn, loss_trn_full, loss_val]
     """
 
-    def __init__(self, indim, outdim):
+    def __init__(self, indim, outdim, device='cpu'):
         """Initialization.
 
         Args:
@@ -36,6 +36,7 @@ class MLPBase(torch.nn.Module):
         self.best_model = None
         self.trained = False
         self.history = None
+        self.device = device
 
 
     def forward(self, x):
@@ -62,10 +63,13 @@ class MLPBase(torch.nn.Module):
         Note:
             Both input and outputs are numpy arrays.
         """
+
+        device = self.best_model.device
+
         if self.trained:
-            return npy(self.best_model(tch(x)))
+            return npy(self.best_model(tch(x, device=device)))
         else:
-            return npy(self.forward(tch(x)))
+            return npy(self.forward(tch(x, device=device)))
 
     def numpar(self):
         """Get the number of parameters of NN.

--- a/quinn/nns/nnwrap.py
+++ b/quinn/nns/nnwrap.py
@@ -34,7 +34,8 @@ class NNWrap():
         Returns:
             np.ndarray: A numpy output array of size `(N,o)`.
         """
-        return npy(self.nnmodel.forward(tch(x)))
+        device = self.nnmodel.device 
+        return npy(self.nnmodel.forward(tch(x, device=device)))
 
     def p_flatten(self):
         """Flattens all parameters into an array.
@@ -65,8 +66,9 @@ class NNWrap():
         Note:
             Returning the list is secondary. The most important result is that this function internally fills the values of corresponding parameters.
         """
-
-        ll = [tch(flat_parameter[s:e]) for (s, e) in self.indices]
+        # FIXME: we should only allocate tensors in initialization. 
+        device = self.nnmodel.device
+        ll = [tch(flat_parameter[s:e],device=device) for (s, e) in self.indices]
         for i, p in enumerate(self.nnmodel.parameters()):
             if len(p.shape)>0:
                 ll[i] = ll[i].view(*p.shape)
@@ -89,7 +91,8 @@ def nnwrapper(x, nnmodel):
     Returns:
         np.ndarray: An output numpy array of size `(N,o)`.
     """
-    return npy(nnmodel.forward(tch(x)))
+    device = self.nnmodel.device 
+    return npy(nnmodel.forward(tch(x,device=device)))
 
 
 def nn_surrogate(x, *otherpars):

--- a/quinn/nns/rnet.py
+++ b/quinn/nns/rnet.py
@@ -36,7 +36,7 @@ class RNet(MLPBase):
         paramsw (list[torch.nn.Parameter]): List of Resnet weight matrices.
         paramsb (list[torch.nn.Parameter]): List of Resnet bias vectors.
     """
-    def __init__(self, rdim, nlayers, wp_function=None, indim=None, outdim=None, biasorno=True, nonlin=True, mlp=False, layer_pre=False, layer_post=False,final_layer=None):
+    def __init__(self, rdim, nlayers, wp_function=None, indim=None, outdim=None, biasorno=True, nonlin=True, mlp=False, layer_pre=False, layer_post=False,final_layer=None,device='cpu'):
         """Instantiate ResNet object.
 
         Args:
@@ -52,7 +52,7 @@ class RNet(MLPBase):
             layer_post (bool, optional): Whether there is a post-resnet linear layer. Defaults to False.
             final_layer (str, optional): If there is a final layer function. Two options: "exp" for exponential function; "sum" for sum function which will reduce rank of the output tensor. Defaults to no final layer.
         """
-        super().__init__(indim, outdim)
+        super().__init__(indim, outdim, device=device)
         if self.indim is None:
             self.indim = rdim
         if self.outdim is None:
@@ -109,6 +109,8 @@ class RNet(MLPBase):
             self.activ = torch.nn.Tanh()
         else:
             self.activ = torch.nn.Identity()
+
+        self.to(device)    
 
     def forward(self, x):
         r"""Forward function.

--- a/quinn/nns/rnet.py
+++ b/quinn/nns/rnet.py
@@ -35,6 +35,7 @@ class RNet(MLPBase):
         bias_post (torch.nn.Parameter): Bias vector of post-resnet layer, if any.
         paramsw (list[torch.nn.Parameter]): List of Resnet weight matrices.
         paramsb (list[torch.nn.Parameter]): List of Resnet bias vectors.
+        device (str): It represents where computations are performed and tensors are allocated. Default to cpu.
     """
     def __init__(self, rdim, nlayers, wp_function=None, indim=None, outdim=None, biasorno=True, nonlin=True, mlp=False, layer_pre=False, layer_post=False,final_layer=None,device='cpu'):
         """Instantiate ResNet object.
@@ -51,6 +52,7 @@ class RNet(MLPBase):
             layer_pre (bool, optional): Whether there is a pre-resnet linear layer. Defaults to False.
             layer_post (bool, optional): Whether there is a post-resnet linear layer. Defaults to False.
             final_layer (str, optional): If there is a final layer function. Two options: "exp" for exponential function; "sum" for sum function which will reduce rank of the output tensor. Defaults to no final layer.
+            device (str): It represents where computations are performed and tensors are allocated. Default to cpu.
         """
         super().__init__(indim, outdim, device=device)
         if self.indim is None:

--- a/quinn/nns/tchutils.py
+++ b/quinn/nns/tchutils.py
@@ -20,7 +20,7 @@ def tch(arr, device='cpu', rgrad=True):
     """
     # return torch.from_numpy(arr.astype(np.double)).to(device)
     # return torch.from_numpy(arr).double()
-    return torch.tensor(arr, requires_grad=rgrad)
+    return torch.tensor(arr, requires_grad=rgrad, device=device)
 
 
 def npy(arr):
@@ -33,7 +33,7 @@ def npy(arr):
         np.ndarray: Numpy array of the same size as the input torch tensor.
     """
     # return data.detach().numpy()
-    return arr.data.numpy()
+    return arr.cpu().data.numpy()
 
 def print_nnparams(nnmodel, names_only=False):
         """Print parameter names of a PyTorch NN module and optionally, values.
@@ -95,7 +95,8 @@ def nnfit(nnmodel, xtrn, ytrn, val=None,
           nepochs=5000, batch_size=None,
           gradcheck=False,
           scheduler_lr=None,
-          freq_out=100, freq_plot=1000, lhist_suffix=''):
+          freq_out=100, freq_plot=1000, lhist_suffix=''
+          ):
     r"""Generic PyTorch NN fit function that is utilized in appropriate NN classes.
 
     Args:
@@ -161,9 +162,10 @@ def nnfit(nnmodel, xtrn, ytrn, val=None,
     if batch_size is None or batch_size > ntrn:
         batch_size = ntrn
 
-
-    xtrn_ = tch(xtrn)
-    ytrn_ = tch(ytrn)
+    device = nnmodel.device
+    
+    xtrn_ = tch(xtrn , device=device)
+    ytrn_ = tch(ytrn , device=device)
 
     # Validation data
     if val is None:
@@ -171,9 +173,11 @@ def nnfit(nnmodel, xtrn, ytrn, val=None,
     else:
         xval, yval = val
 
-    xval_ = tch(xval)
-    yval_ = tch(yval)
-
+    xval_ = tch(xval , device=device)
+    yval_ = tch(yval , device=device)
+    
+    # print("device: ", device)
+    # print("xval_ is device: ", xval_.get_device(), xval_.device)
     # Training process
     fit_info = {'best_fepoch': 0, 'best_epoch': 0,
                 'best_loss': 1.e+100, 'best_nnmodel': nnmodel,

--- a/quinn/nns/tchutils.py
+++ b/quinn/nns/tchutils.py
@@ -12,7 +12,7 @@ def tch(arr, device='cpu', rgrad=True):
 
     Args:
         arr (np.ndarray): A numpy array of any size.
-        device (str, optional): Device to send to. The usage is commented out for now.
+        device (str, optional): It represents where tensors are allocated. Default to cpu.
         rgrad (bool, optional): Whether to require gradient tracking or not.
 
     Returns:
@@ -24,7 +24,7 @@ def tch(arr, device='cpu', rgrad=True):
 
 
 def npy(arr):
-    """Convert a torch tensor to numpy array.
+    """Convert a torch tensor to numpy array. 
 
     Args:
         arr (torch.Tensor): Torch tensor of any size.

--- a/quinn/vi/rvs.py
+++ b/quinn/vi/rvs.py
@@ -80,8 +80,8 @@ class Gaussian(RV):
             sigma = torch.log1p(torch.exp(self.rho))
         else:
             sigma = torch.exp(self.logsigma)
-
-        epsilon = self.normal.sample(sigma.size())
+        # FIXME: compute epsilon with pyTorch to avoid transfer data from host to device
+        epsilon = self.normal.sample(sigma.size()).to(self.mu.device)
         return self.mu + sigma * epsilon
 
     def log_prob(self, x):


### PR DESCRIPTION
To enable runs on GPUs with quinn, we added the attribute `device` to the NN model base class. The device attribute, which defaults to` cpu`, is use to transfer data from `host` to `device`. When creating a new NN model, we only need to pass the `device` attribute. In the initialization of NN model, we transfer the model parameters to `device`. Before the training loop, we employ this attribute to transfer the training and validation data sets to `device`. Furthermore, for model predictions, this attribute is employed to transfer the prediction samples to `device`. Finally, model predictions are return as NumPy arrays; therefore, we transfer the model outputs from `device` to `host`.  

**Notes**:
- NN model base class has a device attribute which defaults to `cpu`.
- Use device = `torch.device(device_id if torch.cuda.is_available() else 'cpu')` to set device attribute, where `device_id` is: `cuda:0`, or `cuda:1`, or `cuda:2 `…
- Model parameters are transferred to device in the initialization of the NN model.
- Enable input “device” in `tch` function. 
- Transfer data from device to host in npy using `.cpu()`.
- Transfer tensors to `device` in vi and mcmc.
